### PR TITLE
fix: updating swagger generation to use same tag between controllers #8

### DIFF
--- a/src/TodoApp.Api.Http/Controllers/Todo/v1/Delete/TodoDeleteItemController.cs
+++ b/src/TodoApp.Api.Http/Controllers/Todo/v1/Delete/TodoDeleteItemController.cs
@@ -7,6 +7,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using TodoApp.Application.UseCases.Todo.Delete;
 using TodoApp.Api.Http.Common;
+using Swashbuckle.AspNetCore.Annotations;
 
 namespace TodoApp.Api.Http.Controllers.Todo.v1.Delete
 {
@@ -31,6 +32,7 @@ namespace TodoApp.Api.Http.Controllers.Todo.v1.Delete
 		/// <response code="500">Unexpected error</response>
 		[HttpDelete]
 		[Route("{id}")]
+		[SwaggerOperation(Tags = [V1TodoTag])]
 		[ProducesResponseType(StatusCodes.Status204NoContent)]
 		[ProducesResponseType(StatusCodes.Status404NotFound)]
 		[ProducesResponseType(typeof(ErrorDetailsResponse), StatusCodes.Status500InternalServerError)]

--- a/src/TodoApp.Api.Http/Controllers/Todo/v1/GetList/TodoGetListController.cs
+++ b/src/TodoApp.Api.Http/Controllers/Todo/v1/GetList/TodoGetListController.cs
@@ -9,6 +9,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using TodoApp.Application.UseCases.Todo.List;
 using TodoApp.Api.Http.Common;
+using Swashbuckle.AspNetCore.Annotations;
 
 namespace TodoApp.Api.Http.Controllers.Todo.v1.GetList
 {
@@ -33,6 +34,7 @@ namespace TodoApp.Api.Http.Controllers.Todo.v1.GetList
 		/// <response code="200">Returns the list of todo items</response>
 		/// <response code="500">Unexpected error</response>
 		[HttpGet]
+		[SwaggerOperation(Tags = [V1TodoTag])]
 		[ProducesResponseType(typeof(IEnumerable<TodoGetListItemResponse>), StatusCodes.Status200OK)]
 		[ProducesResponseType(typeof(ErrorDetailsResponse), StatusCodes.Status500InternalServerError)]
 		public async Task<IActionResult> Get([FromQuery] string filter, CancellationToken cancellationToken)

--- a/src/TodoApp.Api.Http/Controllers/Todo/v1/GetSingle/TodoGetItemController.cs
+++ b/src/TodoApp.Api.Http/Controllers/Todo/v1/GetSingle/TodoGetItemController.cs
@@ -8,6 +8,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using TodoApp.Application.UseCases.Todo.Get;
 using TodoApp.Api.Http.Common;
+using Swashbuckle.AspNetCore.Annotations;
 
 namespace TodoApp.Api.Http.Controllers.Todo.v1.GetSingle
 {
@@ -36,6 +37,7 @@ namespace TodoApp.Api.Http.Controllers.Todo.v1.GetSingle
 		/// <response code="500">Unexpected error</response>
 		[HttpGet]
 		[Route("{id}")]
+		[SwaggerOperation(Tags = [V1TodoTag])]
 		[ProducesResponseType(typeof(TodoGetItemResponse), StatusCodes.Status200OK)]
 		[ProducesResponseType(StatusCodes.Status404NotFound)]
 		[ProducesResponseType(typeof(ErrorDetailsResponse), StatusCodes.Status400BadRequest)]

--- a/src/TodoApp.Api.Http/Controllers/Todo/v1/Patch/TodoPatchItemController.cs
+++ b/src/TodoApp.Api.Http/Controllers/Todo/v1/Patch/TodoPatchItemController.cs
@@ -7,6 +7,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using TodoApp.Application.UseCases.Todo.Update;
 using TodoApp.Api.Http.Common;
+using Swashbuckle.AspNetCore.Annotations;
 
 namespace TodoApp.Api.Http.Controllers.Todo.v1.Patch
 {
@@ -33,6 +34,7 @@ namespace TodoApp.Api.Http.Controllers.Todo.v1.Patch
 		/// <response code="500">Unexpected error</response>
 		[HttpPatch]
 		[Route("{id}/state")]
+		[SwaggerOperation(Tags = [V1TodoTag])]
 		[ProducesResponseType(StatusCodes.Status204NoContent)]
 		[ProducesResponseType(typeof(ErrorDetailsResponse), StatusCodes.Status400BadRequest)]
 		[ProducesResponseType(StatusCodes.Status404NotFound)]

--- a/src/TodoApp.Api.Http/Controllers/Todo/v1/Post/TodoCreateItemController.cs
+++ b/src/TodoApp.Api.Http/Controllers/Todo/v1/Post/TodoCreateItemController.cs
@@ -7,6 +7,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using TodoApp.Application.UseCases.Todo.Create;
 using TodoApp.Api.Http.Common;
+using Swashbuckle.AspNetCore.Annotations;
 
 namespace TodoApp.Api.Http.Controllers.Todo.v1.Post
 {
@@ -31,6 +32,7 @@ namespace TodoApp.Api.Http.Controllers.Todo.v1.Post
 		/// <response code="400">Request has is not valid with the given parameters</response>
 		/// <response code="500">Unexpected error</response>
 		[HttpPost]
+		[SwaggerOperation(Tags = [V1TodoTag])]
 		[ProducesResponseType(StatusCodes.Status201Created)]
 		[ProducesResponseType(typeof(ErrorDetailsResponse), StatusCodes.Status400BadRequest)]
 		[ProducesResponseType(typeof(ErrorDetailsResponse), StatusCodes.Status500InternalServerError)]

--- a/src/TodoApp.Api.Http/Controllers/Todo/v1/Put/TodoPutItemController.cs
+++ b/src/TodoApp.Api.Http/Controllers/Todo/v1/Put/TodoPutItemController.cs
@@ -8,6 +8,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using TodoApp.Application.UseCases.Todo.Update;
 using TodoApp.Api.Http.Common;
+using Swashbuckle.AspNetCore.Annotations;
 
 namespace TodoApp.Api.Http.Controllers.Todo.v1.Put
 {
@@ -34,6 +35,7 @@ namespace TodoApp.Api.Http.Controllers.Todo.v1.Put
 		/// <response code="500">Unexpected error</response>
 		[HttpPut]
 		[Route("{id}")]
+		[SwaggerOperation(Tags = [V1TodoTag])]
 		[ProducesResponseType(StatusCodes.Status204NoContent)]
 		[ProducesResponseType(typeof(ErrorDetailsResponse), StatusCodes.Status400BadRequest)]
 		[ProducesResponseType(StatusCodes.Status404NotFound)]

--- a/src/TodoApp.Api.Http/Controllers/Todo/v1/TodoJsonControllerBase.cs
+++ b/src/TodoApp.Api.Http/Controllers/Todo/v1/TodoJsonControllerBase.cs
@@ -6,5 +6,7 @@ namespace TodoApp.Api.Http.Controllers.Todo.v1
 	[Route("v1/todo")]
 	[Produces("application/json")]
 	public abstract class TodoJsonControllerBase : ControllerBase
-	{ }
+	{
+		protected const string V1TodoTag = "V1 Todo";
+	}
 }

--- a/src/TodoApp.Api.Http/DependencyInjection.cs
+++ b/src/TodoApp.Api.Http/DependencyInjection.cs
@@ -19,9 +19,9 @@ namespace TodoApp.Api.Http
 			services.AddHealthChecks()
 				.AddCheck<DatabaseHealthCheck>(nameof(DatabaseHealthCheck));
 
-			// TODO: Fix the organization of Endpoints on Swagger view
 			services.AddSwaggerGen(c =>
 			{
+				c.EnableAnnotations();
 				c.SwaggerDoc("v1", new OpenApiInfo
 				{
 					Version = "v1",

--- a/src/TodoApp.Api.Http/TodoApp.Api.Http.csproj
+++ b/src/TodoApp.Api.Http/TodoApp.Api.Http.csproj
@@ -13,6 +13,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="7.0.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="5.6.3" />
+    <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="6.5.0" />
   </ItemGroup>
 
   <ItemGroup> 


### PR DESCRIPTION
This is making usage of the Annotations library to better have control of swagger page generation.

Fix #8 